### PR TITLE
Small fixes on smtp and imap

### DIFF
--- a/smail
+++ b/smail
@@ -323,7 +323,7 @@ smtp() {
 		11) send_smtp "quit"; state=12 ;;
 		13) exit ;;
 		-1|-3|11) exit ;;
-		*) sleep 1 ;;
+		# *) sleep 1 ;;
 	esac
 }
 
@@ -686,6 +686,7 @@ case "$op" in
 		}
 
 		state=0
+		send_smtp "ehlo $smtpserver"
 		loop_smtp
 		;;
 

--- a/smail
+++ b/smail
@@ -20,10 +20,10 @@ usage() {
 	echo "Options for send command:"
 	echo "  -t,--to	list of emails to send to (comma separated)"
 	echo "  -s,--subject	email subject"
-	echo "  --cc		carbon copy list of emails"	
+	echo "  --cc		carbon copy list of emails"
 	echo "  --cco		hidden carbon copy list of emails"
 	echo "  -f,--file	file to be used as body"
-	echo ""	
+	echo ""
 	echo "Examples:"
 	echo "  smail config	Run the configuration script"
 	echo "  smail		Read emails"
@@ -195,7 +195,7 @@ compose() {
 		echo "Content-Type: multipart/mixed;"
 		echo " boundary= \"$boundary\""
 		echo ""
-	
+
 		echo "--$boundary"
 		echo 'Content-Type: text/plain; charset=US-ASCII'
 		echo ""
@@ -316,7 +316,7 @@ smtp() {
 			fi
 			;;
 		9)
-			cat $cachedir/temp >&"${SMTP[1]}" 
+			cat $cachedir/temp >&"${SMTP[1]}"
 			send_smtp '.'
 			state=10
 			;;
@@ -420,7 +420,7 @@ auth_imap() {
 			return 1
 			break
 			;;
-	
+
 		"a$seq BAD"*)
 			break
 			;;
@@ -444,7 +444,7 @@ reply_email() {
 		do
 			echo "> $line" >> "$cachedir/reply.txt"
 		done < "$cachedir/body.txt"
-		
+
 		smail send -f "$cachedir/reply.txt"
 		rm "$cachedir/reply.txt"
 	fi
@@ -503,7 +503,7 @@ read_email() {
 	arg="$1"
 	[ -z "$arg" ] && echo "Enter id: " && read arg
 	send_imap "fetch $arg BODY[TEXT]"
-		
+
 	read_body
 }
 
@@ -511,7 +511,7 @@ peek_email() {
 	arg="$1"
 	[ -z "$arg" ] && echo "Enter id: " && read arg
 	send_imap "fetch $arg BODY.PEEK[TEXT]"
-		
+
 	read_body
 }
 
@@ -547,7 +547,7 @@ get_email_info() {
 	from="$(echo "$from" | sed 's/ <.*>//')"
 	from="$(decode_string "$from")"
 	subj="$(decode_string "$subj" | cut -b 1-$rest)"
-	
+
 	printf "%-6s %-28s %-30s %s" "$1" "$date" "${from,1,30}" "$subj"
 	echo ""
 }
@@ -644,7 +644,7 @@ function loop_imap() {
 				[ -e $debug ] || echo "Unrecognized state"
 				;;
 		esac
-	done 
+	done
 }
 
 ### ---- Main program ---------------------------------------------------- ###
@@ -668,15 +668,15 @@ read_opts "$@"
 [ -e "$configfile" ] || configure
 . "$configfile"
 
-case "$op" in 
+case "$op" in
 	"send")
-		compose 
+		compose
 
 		coproc SMTP {
 			if [ -e "$smtptls" ]
 			then
 				[ -e $debug ] || >&2 echo "Starting nc"
-				nc "$smtpserver" "$smtpport" 
+				nc "$smtpserver" "$smtpport"
 			else
 				[ -e $debug ] || >&2 echo "Starting openssl"
 				openssl s_client -starttls smtp \
@@ -691,7 +691,7 @@ case "$op" in
 
 	"read" | "")
 		[[ $(tput cols) -le 74 ]] && echo "Needs at least 74 columns" && exit
-		
+
 		coproc IMAP {
 			openssl s_client -quiet -connect "$imapserver":"$impapport" \
 			-crlf 2> /dev/null

--- a/smail
+++ b/smail
@@ -410,14 +410,14 @@ send_imap() {
 
 auth_imap() {
 	[ -e $debug ] || echo "Authenticating"
-	send_imap "login $email $password"
+	send_imap "login \"$email\" \"$password\""
 
 	while read -r -u ${IMAP[0]} msg
 	do
 		[ -e $debug ] || echo "received: $msg"
 		case "$msg" in
 		"a$seq OK"*)
-			return 1
+			return 0
 			break
 			;;
 
@@ -427,7 +427,7 @@ auth_imap() {
 		esac
 	done
 
-	return 0
+	return 1
 }
 
 select_inbox() {


### PR DESCRIPTION
Besides the trailing whitespace that my editor automatically trimmed, this PR fixes:

1. stmp getting stuck as there's no initial mail-server message
	The `loop_smtp()` function expects a first message from the mail server, but when using openssl:
	```sh
	openssl s_client -starttls smtp -connect smtp.gmail.com:587 -crlf -quiet 2>/dev/null
	```
	the command outputs nothing until user first sends an `ehlo xxx` message
2. In `auth_imap()` the login command will fails if `$password` contains whitespace (hence the `"` quotes). 
	The return status was also inverted (should returns 0 to indicates success).
